### PR TITLE
remove ‘inspect’ fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,14 +91,11 @@
     /* eslint-enable key-spacing */
   };
 
-  var custom = util.inspect.custom;
+  var custom = util.inspect.custom;  // added in Node.js v6.6.0
   /* istanbul ignore else */
   if (typeof custom === 'symbol') {
     Left$prototype[custom] = Left$prototype$show;
     Right$prototype[custom] = Right$prototype$show;
-  } else {
-    Left$prototype.inspect = Left$prototype$show;
-    Right$prototype.inspect = Right$prototype$show;
   }
 
   //. `Either a b` satisfies the following [Fantasy Land][] specifications:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "/index.js",
     "/package.json"
   ],
+  "engines": {
+    "node": ">=6.6.0"
+  },
   "dependencies": {
     "sanctuary-show": "2.0.0",
     "sanctuary-type-classes": "12.1.0"


### PR DESCRIPTION
According to <https://nodejs.org/en/download/releases/>, v6.6.0 was released on 2016-09-14. The fallback for older versions of Node.js is no longer warranted.
